### PR TITLE
Add Swoot

### DIFF
--- a/src/user-agents.json
+++ b/src/user-agents.json
@@ -558,6 +558,12 @@
     },
     {
         "user_agents": [
+            "^Swoot\\/"
+        ],
+        "app": "Swoot"
+    },
+    {
+        "user_agents": [
             "^Trackable\\/"
         ],
         "bot": true


### PR DESCRIPTION
Thanks for setting up this project!

A few questions I had when creating this PR:

1) The regex is the same for both entries below because we use similar user agents across our apps (streaming and downloading) and our RSS feed crawler. Does adding two entries still make sense here? From the perspective of someone using this data, I think it would be nice for them to see that there are multiple different sources for these requests.
2) Is using one entry for iOS and Android apps and ignoring the `os` property the intended setup? At first I thought that the `os` property might allow an array like `"os": ["android", "ios"]` for clarity.