### PR TITLE
add gpodder.net user agent

### DIFF
--- a/src/user-agents.json
+++ b/src/user-agents.json
@@ -260,6 +260,12 @@
     },
     {
         "user_agents": [
+            "^gpodder.net"
+        ],
+        "app": "https://gpodder.net"
+    },
+    {
+        "user_agents": [
             "^GStreamer"
         ],
         "device": "radio"


### PR DESCRIPTION
gpodder.net is a libre web service that allows you to manage
your podcast subscriptions and discover new content.

If you use multiple devices, you can synchronize subscriptions
and your listening progress. 