### PR TITLE
Add additional user agent for Pocket Casts

### DIFF
--- a/src/user-agents.json
+++ b/src/user-agents.json
@@ -415,7 +415,8 @@
     },
     {
         "user_agents": [
-            "^Pocket Casts"
+            "^Pocket Casts",
+            "^PocketCasts\\/"
         ],
         "app": "Pocket Casts",
         "device": "phone"


### PR DESCRIPTION
When fetching episodes, Pocket Casts uses the user agent `Pocket Casts`. When
fetching feeds (from their servers), Pocket Casts uses the user agent
`PocketCasts/1.0 (Pocket Casts Feed Parser; +http://pocketcasts.com/)`