### PR TITLE
Update podCloud data

### DIFF
--- a/src/user-agents.json
+++ b/src/user-agents.json
@@ -828,6 +828,6 @@
         "user_agents": [
             "podCloud"
         ],
-        "app": "PodCloud"
+        "bot": true
     }
 ]


### PR DESCRIPTION
Requests with podCloud user-agent are actually bot requests :
	Feed updates every 6 hours, media tags retriever once per media etc

End users using podCloud and listening to medias are identified with their browser user agent.