### PR TITLE
Splitting Apple Podcasts UA

### DIFF
--- a/src/user-agents.json
+++ b/src/user-agents.json
@@ -145,9 +145,18 @@
     },
     {
         "user_agents": [
-            "^Podcasts/"
+            "^Podcasts\/.*\\(.*\\)"
         ],
-        "app": "Apple Podcasts"
+        "app": "Apple Podcasts",
+        "device": "pc",
+        "os": "macos"
+    },
+    {
+        "user_agents": [
+            "^Podcasts\/.*\\d$"
+        ],
+        "app": "Apple Podcasts",
+        "os": "ios"
     },
     {
         "user_agents": [

--- a/src/user-agents.json
+++ b/src/user-agents.json
@@ -145,7 +145,7 @@
     },
     {
         "user_agents": [
-            "^Podcasts\/.*\\(.*\\)"
+            "^Podcasts/.*\\(.*\\)"
         ],
         "app": "Apple Podcasts",
         "device": "pc",
@@ -153,7 +153,7 @@
     },
     {
         "user_agents": [
-            "^Podcasts\/.*\\d$"
+            "^Podcasts/.*\\d$"
         ],
         "app": "Apple Podcasts",
         "os": "ios"


### PR DESCRIPTION
Now that Catalina is released, the desktop version of Apple Podcasts has an additional `(x86_64)` at the end for when a full download is triggered.  This regex change splits the UA parser into two versions, one where it detects the non-desktop version and one that detects the desktop version.  Unfortunately, there isn't any detail about the kinds of devices that have triggered the download.