### PR TITLE
Firefox on Android

### DIFF
--- a/src/user-agents.json
+++ b/src/user-agents.json
@@ -383,7 +383,7 @@
     },
     {
         "user_agents": [
-            "Android.*Focus/"
+            "Android.*(Focus|Firefox)/"
         ],
         "app": "Firefox",
         "os": "android"


### PR DESCRIPTION
Fixed regexp for matching Firefox on Android

Tested on two apps on Android 7 phone:

 * Mozilla Firefox 68.1.1 (newest in Google Play)
 * Firefox Preview 1.0.1926 (newest in Google Play)

Both apps present themselves as `Mozilla/5.0 (Android 7.1.2; Mobile; rv:68.0) Gecko/68.0 Firefox/68.0`