### PR TITLE
Add The Economist ios and android app

### DIFF
--- a/src/user-agents.json
+++ b/src/user-agents.json
@@ -1484,5 +1484,27 @@
             "com.evolve.podcast/3.10.1 (iPhone; ) (build 951, iOS 13.3)"
         ],
         "os": "ios"
+    },
+    {
+        "user_agents": [
+            "^lamarr-iOS"
+        ],
+        "app": "The Economist",
+        "device": "phone",
+        "os": "ios",
+        "examples": [
+            "lamarr-iOS-2.20.3-116"
+        ]
+    },
+    {
+        "user_agents": [
+            "^lamarr-android"
+        ],
+        "app": "The Economist",
+        "device": "phone",
+        "os": "android",
+        "examples": [
+            "lamarr-android-2.18.1-21810"
+        ]
     }
 ]


### PR DESCRIPTION
Add The Economist ios and android app user agents.

More examples: 
```
lamarr-iOS-2.20.3-116
lamarr-iOS-2.19.4-111
lamarr-iOS-2.20.1-114
lamarr-iOS-2.20.2-115
lamarr-android-2.20.4-22040
lamarr-android-2.20.2-22020
lamarr-iOS-2.20.4-117
lamarr-android-2.20.3-22030
lamarr-iOS-2.19.3-110
lamarr-iOS-2.19.1-107
lamarr-iOS-2.20.0-113
lamarr-iOS-2.18.0-104
lamarr-android-2.20.1-22011
lamarr-android-2.19.3-21931
lamarr-iOS-2.19.2-108
lamarr-android-2.19.1-21910
lamarr-iOS-2.19.0-106
lamarr-android-2.21.0-release-refe062a-feature-LAM-2641-1-22100
lamarr-iOS-2.20.3-Enterprise-hotfix-removeConditionalRendering-r8f8dfd65-#2-116
lamarr-iOS-2.20.4-Enterprise-hotfix-androidMusicControl-r7562f3d2-#5-117
lamarr-android-2.21.0-release-raed86e6-feature-LAM-2751-5-22100
lamarr-android-2.20.4-debug-r238b5e73-hotfix-androidMusicControl-0-22040
lamarr-android-2.20.3-release-r8f8dfd65-hotfix-removeConditionalRendering-0-22030
lamarr-android-2.20.2-debug-r30d82d79-develop-0-22020
lamarr-android-2.21.0-release-rac0526a-develop-1392-22100
lamarr-android-2.18.1-21810
```