### PR TITLE
Add Broadway Podcast Network

### DIFF
--- a/src/user-agents.json
+++ b/src/user-agents.json
@@ -322,6 +322,18 @@
     },
     {
         "user_agents": [
+          "BroadwayPodcastNetwork/iOS"
+        ],
+        "app": "Broadway Podcast Network",
+        "description": "The Broadway Podcast Network iOS App",
+        "device": "phone",
+        "examples": [
+          "BroadwayPodcastNetwork/iOS"
+        ],
+        "os": "ios"
+    },
+    {
+        "user_agents": [
             "^Cast(?:b|B)ox/.+Android"
         ],
         "app": "CastBox",


### PR DESCRIPTION
The Broadway Podcast Network is a hub for podcasts centered around the Broadway theater community. This user agent string is for our new iOS podcast player app, to be released to the app store in a few days. Thank you!