### PR TITLE
Update the economist mobile apps

### DIFF
--- a/src/user-agents.json
+++ b/src/user-agents.json
@@ -931,24 +931,28 @@
     },
     {
         "user_agents": [
-            "^lamarr-iOS"
+            "^lamarr-iOS",
+            "^TheEconomist-Lamarr-ios"
         ],
         "app": "The Economist",
         "device": "phone",
         "os": "ios",
         "examples": [
-            "lamarr-iOS-2.20.3-116"
+            "lamarr-iOS-2.20.3-116",
+            "TheEconomist-Lamarr-ios-2.22.2-12002"
         ]
     },
     {
         "user_agents": [
-            "^lamarr-android"
+            "^lamarr-android",
+            "^TheEconomist-Lamarr-android"
         ],
         "app": "The Economist",
         "device": "phone",
         "os": "android",
         "examples": [
-            "lamarr-android-2.18.1-21810"
+            "lamarr-android-2.18.1-21810",
+            "TheEconomist-Lamarr-android-2.22.2-12002"
         ]
     },
     {


### PR DESCRIPTION
#### What’s the purpose of this PR?
The Economist has changed  the user-agent names from `lamarr-*` to `TheEconomist-Lamarr-*`

#### Examples:
Android:
```
TheEconomist-Lamarr-android-2.22.2-12002
```

iOS
```
TheEconomist-Lamarr-ios-2.22.2-12002
```