### PR TITLE
Changes device type for Overcast

### DIFF
--- a/src/user-agents.json
+++ b/src/user-agents.json
@@ -1266,8 +1266,7 @@
         "examples": [
             "Overcast/3.0 (+http://overcast.fm/; iOS podcast app)"
         ],
-        "os": "ios",
-        "device": "phone"
+        "os": "ios"
     },
     {
         "user_agents": [


### PR DESCRIPTION
Yes, most Overcast listening happens on the phone, but there is a legit Overcast iPad app, so right now we don't know that listening is happening on the phone, and I'd rather we go with what we know than what we assume.