### PR TITLE
Splits Deezer user agents

### DIFF
--- a/src/user-agents.json
+++ b/src/user-agents.json
@@ -507,7 +507,6 @@
             "Deezer/.*Android;"
         ],
         "app": "Deezer",
-        "device": "phone",
         "os": "android",
         "examples": [
             "Deezer/6.2.2.80 (Android; 9; Mobile; fr) samsung SM-G950F",
@@ -528,13 +527,25 @@
     },
     {
         "user_agents": [
-            "^Deezer.*Electron"
+            "^Deezer.*Electron; windows"
         ],
         "app": "Deezer",
         "examples": [
-            "Deezer/4.20.0 (Electron; windows/10.0.18362; Desktop; fr)",
+            "Deezer/4.20.0 (Electron; windows/10.0.18362; Desktop; fr)"
+        ],
+        "device": "pc",
+        "os": "windows"
+    },
+    {
+        "user_agents": [
+            "^Deezer.*Electron; osx"
+        ],
+        "app": "Deezer",
+        "examples": [
             "Deezer/4.20.0 (Electron; osx/10.14.6; Desktop; fr)"
-        ]
+        ],
+        "device": "pc",
+        "os": "macos"
     },
     {
         "user_agents": [


### PR DESCRIPTION
Differentiates between Deezer's Electron app in Windows and Mac, and removes the "phone" device type from Android as we seldom know when a device is a phone or a tablet on Android