### PR TITLE
add downcast bot

### DIFF
--- a/src/user-agents.json
+++ b/src/user-agents.json
@@ -678,7 +678,17 @@
         "os": "macos",
         "device": "pc"
     },
-        {
+    {
+        "user_agents": [
+            "downcast feed consumer/"
+        ],
+        "app": "Downcast",
+        "examples": [
+            "downcast feed consumer/0.0.175; (mode=dev; id=u2NgjBSPM6; downcast.fm)"
+        ],
+        "bot": true
+    },
+    {
         "user_agents": [
             "Xbox.+Edge/"
         ],


### PR DESCRIPTION
This user agent seems to be downcast indexing bot : regular, and only a few IPs are seen, and they all are registered in servers ip ranges ( Digital Ocean etc )

I'm waiting for their [confirmation](https://twitter.com/podCloud/status/1392059758992048128) though.