### PR TITLE
Update user-agents.json

### DIFF
--- a/src/user-agents.json
+++ b/src/user-agents.json
@@ -1599,6 +1599,17 @@
     },
     {
         "user_agents": [
+            "^Overcast//1.0 Podcast Sync .*"
+        ],
+        "app": "Overcast feed parser",
+        "examples": [
+            "Overcast//1.0 Podcast Sync (+http:////overcast.fm//)"
+        ],
+        "developer_notes": "Lisofc says: there is also this one for Overcast Bot",
+        "bot": true
+    },
+    {
+        "user_agents": [
             "^PandoraRSSCrawler"
         ],
         "bot": true,


### PR DESCRIPTION
In my audio logs, I can see that "Overcast/1.0 Podcast Sync (+http:////overcast.fm//)" and this pattern is not in the json file.