### PR TITLE
Update Podverse user agent so that it does not include extra WebView info

### DIFF
--- a/src/user-agents.json
+++ b/src/user-agents.json
@@ -1556,23 +1556,21 @@
 	"user_agents": ["^SoundOn\/[d.]+s+bot"],
 	"bot": true
 }, {
-	"user_agents": ["^Podverse\/.*Android Mobile App\/"],
+	"user_agents": ["^Podverse\/.*Android Mobile App"],
 	"app": "Podverse",
 	"device": "phone",
 	"os": "android",
 	"info_url": "https:\/\/play.google.com\/store\/apps\/details?id=com.podverse&hl=en_US",
-	"description": "Open source podcast catcher for Android, with clip-sharing, playlists, device syncing and more.",
-	"examples": ["Podverse/F-Droid Android Mobile App/","Podverse/Android Mobile App/Mozilla/5.0 (Linux; Android 12; SM-S134DL Build/SP1A.210812.016; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/105.0.5195.136 Mobile Safari/537.36"],
-	"developer_notes": "The standard device user agent is concatenated to the end of the Podverse\/Android Mobile App\/ user agent."
+	"examples": ["Podverse/F-Droid Android Mobile App","Podverse/Android Mobile App"],
+	"description": "Open source podcast catcher for Android, with clip-sharing, playlists, device syncing and more."
 }, {
-	"user_agents": ["^Podverse\/iOS Mobile App\/"],
+	"user_agents": ["^Podverse\/iOS Mobile App"],
 	"app": "Podverse",
 	"device": "phone",
 	"os": "ios",
-	"examples": ["Podverse\/iOS Mobile App\/Mozilla\/5.0 (iPhone; CPU iPhone OS 13_6_1 like Mac OS X) AppleWebKit\/605.1.15 (KHTML, like Gecko) Mobile\/1234"],
-	"description": "Open source podcast catcher for iOS, with clip-sharing, playlists, device syncing and more.",
 	"info_url": "https:\/\/apps.apple.com\/us\/app\/podverse\/id1390888454",
-	"developer_notes": "The standard device user agent is concatenated to the end of the Podverse\/iOS Mobile App\/ user agent."
+	"examples": ["Podverse\/iOS Mobile App"],
+	"description": "Open source podcast catcher for iOS, with clip-sharing, playlists, device syncing and more.",
 }, {
 	"user_agents": ["^Podverse\/Feed Parser"],
 	"bot": true,


### PR DESCRIPTION
Creating this as a draft for now. This user agent update should go live in Podverse's next mobile app release v4.6.9, but that is not released yet. Expecting it to go live in the next week.

https://github.com/podverse/podverse-rn/issues/1284